### PR TITLE
The rgl material property name is "color".

### DIFF
--- a/R/plotcorr.lba.3d.R
+++ b/R/plotcorr.lba.3d.R
@@ -230,7 +230,7 @@ plotcorr.lba.3d <- function(x,
 
     pch3d(colcoordi[,dim],
           pch = pch.budget,
-          col = col.budget,
+          color = col.budget,
           ...)
 
     aux1_colcoordi <- colcoordi[,dim]


### PR DESCRIPTION
In the upcoming release of rgl, the "color" material property becomes an argument to pch3d.  This means that R CMD check will give a warning if "col" is used instead.  This change should be completely compatible with older rgl versions as well as the upcoming one.